### PR TITLE
Fix error 'Processing the following image' because paths are not properly joined

### DIFF
--- a/src/UI/Shell.cs
+++ b/src/UI/Shell.cs
@@ -1630,7 +1630,7 @@ namespace WindowsFormsApp2
             Invoke(LabelUpdate);
 
             
-            await DetectObjects(input_path + "/" + e.Name); //ai process image
+            await DetectObjects(Path.Combine(input_path, e.Name)); //ai process image
             
             //output Running on Overview Tab
             LabelUpdate = delegate { label2.Text = "Running"; };


### PR DESCRIPTION
This should fix the following error message which is caused by not properly joining paths:

> Processing the following image 'C:\BlueIris\aiinput/Z5AI.20200529_223155515.jpg' failed. Can't reach DeepQuestAI Server at http://192.168.0.113:85.